### PR TITLE
[WIP] Add use of require.css and require.js

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "sculpin/sculpin": "2.*@dev",
 
-        "components/bootstrap": "~2.3.1",
+        "components/bootstrap-default": "~2.3.1",
         "components/jquery": "~1.9.1",
         "components/highlightjs": "~7.3.0",
         "components/font-awesome": "~3.0.2@dev",
@@ -22,6 +22,17 @@
         "dflydev/embedded-composer": "@dev",
         "michelf/php-markdown": "@beta",
         "composer/composer": "@dev"
+    },
+    "extra": {
+        "component": {
+            "styles": [
+                "source/css/style.css",
+                "vendor/components/highlightjs/styles/github.css"
+            ],
+            "files": [
+                "source/css/stack-logo.png"
+            ]
+        }
     },
     "config": {
         "component-dir": "source/components"

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "57b53cd2585311edf325ca0a78a83ae5",
+    "hash": "9b7ec0cdf4ce5ba3043ef71a104149e5",
     "packages": [
         {
             "name": "components/bootstrap",
@@ -59,6 +59,58 @@
                 "css"
             ],
             "time": "2013-04-24 18:00:29"
+        },
+        {
+            "name": "components/bootstrap-default",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/components/bootstrap-default.git",
+                "reference": "2.3.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/components/bootstrap-default/zipball/2.3.1",
+                "reference": "2.3.1",
+                "shasum": ""
+            },
+            "require": {
+                "components/bootstrap": "*"
+            },
+            "type": "component",
+            "extra": {
+                "component": {
+                    "styles": [
+                        "css/bootstrap.css",
+                        "css/bootstrap-responsive.css"
+                    ],
+                    "files": [
+                        "img/glyphicons-halflings.png",
+                        "img/glyphicons-halflings-white.png"
+                    ],
+                    "shim": {
+                        "deps": [
+                            "bootstrap"
+                        ]
+                    }
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Twitter, Inc"
+                }
+            ],
+            "description": "Shim repository for the default theme for Bootstrap.",
+            "homepage": "http://twitter.github.com/bootstrap/",
+            "keywords": [
+                "bootstrap",
+                "css"
+            ],
+            "time": "2013-04-16 05:42:04"
         },
         {
             "name": "components/font-awesome",
@@ -193,16 +245,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "dev-master",
+            "version": "1.0.0-alpha6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/composer.git",
-                "reference": "3aa78431464a695f0c707e33413a0f81a9347a0b"
+                "url": "https://github.com/composer/composer",
+                "reference": "1.0.0-alpha6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/3aa78431464a695f0c707e33413a0f81a9347a0b",
-                "reference": "3aa78431464a695f0c707e33413a0f81a9347a0b",
+                "url": "https://github.com/composer/composer/archive/1.0.0-alpha6.zip",
+                "reference": "1.0.0-alpha6",
                 "shasum": ""
             },
             "require": {
@@ -212,9 +264,6 @@
                 "symfony/console": ">=2.1,<3.0",
                 "symfony/finder": ">=2.1,<3.0",
                 "symfony/process": ">=2.1,<3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": ">=3.7.10.0,<3.8"
             },
             "suggest": {
                 "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
@@ -251,14 +300,14 @@
                     "homepage": "http://www.naderman.de"
                 }
             ],
-            "description": "Dependency Manager",
+            "description": "Package Manager",
             "homepage": "http://getcomposer.org/",
             "keywords": [
                 "autoload",
                 "dependency",
                 "package"
             ],
-            "time": "2013-04-26 09:02:53"
+            "time": "2012-10-23 01:54:25"
         },
         {
             "name": "dflydev/ant-path-matcher",

--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -4,11 +4,7 @@
         <title>{% block full_title %}{% block title %}{{ page.title }}{% endblock %} &mdash; {{ site.title }} &mdash; {{ site.subtitle }}{% endblock %}</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link href="{{ site.url }}/components/bootstrap/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
-        <link href="{{ site.url }}/components/bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet" type="text/css" />
-        <link href="{{ site.url }}/components/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
-        <link href="{{ site.url }}/css/style.css" rel="stylesheet" type="text/css" />
-        <link rel="stylesheet" href="{{ site.url }}/components/highlightjs/styles/github.css" />
+        <link href="{{ site.url }}/components/require.css" rel="stylesheet" type="text/css" />
         <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
         <!--[if lt IE 9]>
             <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -26,26 +22,26 @@
             Go stack some middlewares
         </footer>
 
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-        <script>window.jQuery || document.write('<script src="{{ site.url }}/components/jquery/jquery.min.js"><\/script>')</script>
-        <script src="{{ site.url }}/components/bootstrap/js/bootstrap.min.js"></script>
+        <script src="{{ site.url }}/components/require.js"></script>
+        <script type="text/javascript">
+            {% if site.google_analytics_tracking_id %}
+                var _gaq = _gaq || [];
+                _gaq.push(['_setAccount', '{{ site.google_analytics_tracking_id }}']);
+                _gaq.push(['_trackPageview']);
+                (function() {
+                    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+                    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+                })();
+            {% endif %}
+            require.config({
+                "baseUrl": "{{ site.url }}/components"
+            });
+            require(['highlightjs', 'bootstrap'], function(hljs) {
+                hljs.initHighlighting();
+            });
+        </script>
         {% block scripts %}
         {% endblock %}
-
-        {% if site.google_analytics_tracking_id %}
-        <script type="text/javascript">
-            var _gaq = _gaq || [];
-            _gaq.push(['_setAccount', '{{ site.google_analytics_tracking_id }}']);
-            _gaq.push(['_trackPageview']);
-
-            (function() {
-                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-            })();
-        </script>
-        {% endif %}
-        <script src="{{ site.url }}/components/highlightjs/highlight.pack.js"></script>
-        <script>hljs.initHighlightingOnLoad();</script>
     </body>
 </html>


### PR DESCRIPTION
This is more of brainstorm than a pull request. This makes use of [Component Installer](https://github.com/robloach/component-installer)'s generated `require.js` and `require.css`, reducing the micro-management of dependencies, and the amount of HTTP requests.
- `require.css`: Concatenated stylesheet of all Component CSS files
- `require.js`: Built [RequireJS](http://requirejs.org) configuration for loading scripts, along with their dependencies

@simensen and I had troubles getting RequireJS to pick up the correct base URL in Sculpin. We can get around that by telling Sculpin to register it directly in the template:

``` javascript
require.config({
    "baseUrl": "{{ site.url }}/components"
});
```

Was trying to use `hljs.initHighlightingOnLoad();` here, and it wasn't quite working because I believe at the time the require callback is made, the page is already loaded and the event has already been triggered. I could be wrong though, but it is working with the following:

``` javascript
require(['highlightjs', 'bootstrap'], function(hljs) {
    hljs.initHighlighting();
});
```

Was wondering where this could improve, and was looking for both of your thoughts. I'm trying to get a better understanding of where Component Installer could be better, and how it could satisfy more use cases.

Thanks a lot! Stack looks great :heart: 
