### PR TITLE
Add StackRobots to middlewares page.

### DIFF
--- a/source/middlewares.html
+++ b/source/middlewares.html
@@ -125,5 +125,22 @@ nav_name: middlewares
             </div>
         </div>
     </div>
+    <div class="row-fluid">
+        <div class="span6">
+            <h3>
+                <a href="https://github.com/php-loep/StackRobots">StackRobots</a>
+            </h3>
+            <p class="by">
+                by dongilbert
+            </p>
+            <p>
+                Provides a default robots.txt for non-production environments.
+            </p>
+            <div class="btn-group">
+                <a class="btn" href="https://github.com/php-loep/StackRobots"><i class="icon icon-github"></i> GitHub</a>
+                <a class="btn" href="https://packagist.org/packages/league/stack-robots"><i class="icon icon-archive"></i> Packagist</a>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
I've create a new middleware based on [Cylon](https://github.com/dmathieu/cylon) for Ruby. It provides a default `robots.txt` for non-production environments.
