### PR TITLE
Link to Laravel Framework 4.2 branch

### DIFF
--- a/source/middlewares.html
+++ b/source/middlewares.html
@@ -22,14 +22,14 @@ nav_name: middlewares
         </div>
         <div class="span6">
             <h3>
-                <a href="https://github.com/laravel/framework/tree/master/src/Illuminate/Cookie">CookieGuard</a>
+                <a href="https://github.com/laravel/framework/tree/4.2/src/Illuminate/Cookie">CookieGuard</a>
             </h3>
             <p class="by">
                 by laravel
             </p>
             <p>The laravel cookie guard encrypts outgoing cookies.</p>
             <div class="btn-group">
-                <a class="btn" href="https://github.com/laravel/framework/tree/master/src/Illuminate/Cookie"><i class="icon icon-github"></i> GitHub</a>
+                <a class="btn" href="https://github.com/laravel/framework/tree/4.2/src/Illuminate/Cookie"><i class="icon icon-github"></i> GitHub</a>
                 <a class="btn" href="https://packagist.org/packages/illuminate/cookie"><i class="icon icon-archive"></i> Packagist</a>
             </div>
         </div>


### PR DESCRIPTION
Because master is the 5.0 version in development and the CookieMiddleware will no longer be StackPHP compatible.
