### PR TITLE
Adding Whoops middleware to list of middlewares

### DIFF
--- a/source/middlewares.html
+++ b/source/middlewares.html
@@ -236,6 +236,21 @@ nav_name: middlewares
                 <a class="btn" href="https://packagist.org/packages/pno/throttle"><i class="icon icon-archive"></i> Packagist</a>
             </div>
         </div>
+        <div class="span6">
+            <h3>
+                <a href="https://github.com/thecodingmachine/whoops-stackphp">Whoops wrapper</a>
+            </h3>
+            <p class="by">
+                by moufmouf
+            </p>
+            <p>
+                Stack Middleware for using the Whoops error handling library.
+            </p>
+            <div class="btn-group">
+                <a class="btn" href="https://github.com/thecodingmachine/whoops-stackphp"><i class="icon icon-github"></i> GitHub</a>
+                <a class="btn" href="https://packagist.org/packages/mouf/whoops-stackphp"><i class="icon icon-archive"></i> Packagist</a>
+            </div>
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
I've been working on a very simple middleware wrapper.
It uses the Whoops! library to display errors and exceptions.
I just added the reference to the list of middlewares if you find it useful.
