### PR TITLE
Adding references to 2 new middlewares

### DIFF
--- a/source/middlewares.html
+++ b/source/middlewares.html
@@ -252,5 +252,37 @@ nav_name: middlewares
             </div>
         </div>
     </div>
+    <div class="row-fluid">
+        <div class="span6">
+            <h3>
+                <a href="https://github.com/thecodingmachine/silex-middleware">Silex middleware</a>
+            </h3>
+            <p class="by">
+                by moufmouf
+            </p>
+            <p>
+                Turns a Silex application into a Stack middleware.
+            </p>
+            <div class="btn-group">
+                <a class="btn" href="https://github.com/thecodingmachine/silex-middleware"><i class="icon icon-github"></i> GitHub</a>
+                <a class="btn" href="https://packagist.org/packages/mouf/silex-middleware"><i class="icon icon-archive"></i> Packagist</a>
+            </div>
+        </div>
+        <div class="span6">
+            <h3>
+                <a href="https://github.com/thecodingmachine/whoops-stackphp">Symfony 2 middleware</a>
+            </h3>
+            <p class="by">
+                by moufmouf
+            </p>
+            <p>
+                Turns a Symfony 2 application (i.e. <code>Kernel</code>) into a Stack middleware.
+            </p>
+            <div class="btn-group">
+                <a class="btn" href="https://github.com/thecodingmachine/symfony-middleware"><i class="icon icon-github"></i> GitHub</a>
+                <a class="btn" href="https://packagist.org/packages/mouf/symfony-middleware"><i class="icon icon-archive"></i> Packagist</a>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}

--- a/source/middlewares.html
+++ b/source/middlewares.html
@@ -270,7 +270,7 @@ nav_name: middlewares
         </div>
         <div class="span6">
             <h3>
-                <a href="https://github.com/thecodingmachine/whoops-stackphp">Symfony 2 middleware</a>
+                <a href="https://github.com/thecodingmachine/symfony-middleware">Symfony 2 middleware</a>
             </h3>
             <p class="by">
                 by moufmouf


### PR DESCRIPTION
I'd like to add a reference to 2 new very special middlewares I just wrote:

*silex-middleware* and *symfony-middleware* can turn a Silex application or a Symfony application into a middleware.
This is cool because Silex or Symfony are no more the last "app" that we stack upon. They can now be a part of the middleware to another app.

So you could stack a Silex application in front of a Symfony application, and so on...

I've had a need for those as I was working on a fork of framework-interop (https://github.com/moufmouf/framework-interop/), a project by @mnapoli that makes heavy use of StackPHP and of container-interop to build a web application with many frameworks enabled at once (the test project is having Silex, Symfony 2 and Zend Framework 1 working together in the same application)
